### PR TITLE
Add functionality to give a custom filename when uploading files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
           'flake8-use-fstring==1.1',  # Enforces use of f-strings over .format and %s
           'flake8-print==3.1.4',  # Checks for print statements
           'flake8-docstrings==1.5.0',  # Verifies that all functions/methods have docstrings
-          'flake8-type-annotations==0.1.0',  # Looks for misconfigured type annotations
           'flake8-annotations==2.4.0',  # Enforces type annotation
         ]
         args: ['--enable-extensions=G']


### PR DESCRIPTION
Some basic regex.

Appends `.mp4` to the uploaded file, if there is no file extension. 

In other words, if user names his file `abcd`, it will be named `abcd.mp4`. If the user names the file `abcd.mp4` it will be named `abcd.mp4`.